### PR TITLE
feat: L4-ready Reference Server, adapter smoke tests, release pipeline

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,25 @@
+name: gitleaks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
+          GITLEAKS_ENABLE_SUMMARY: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,31 @@
-name: Create Release
+name: Release
+
+# Tag-driven release pipeline for the OAP spec.
+#
+# On a tag matching v*:
+#   1. Validate every JSON Schema under schemas/v1.0 with ajv-strict.
+#   2. Run the reference server smoke test (npm run smoke in reference/server).
+#   3. Boot the reference server, run the full conformance test-suite against it.
+#   4. Run the adapter smoke tests against the running reference server.
+#   5. Generate a signed self-Conformance Receipt for the reference server using
+#      attest.js and the repository signing key.
+#   6. Create the GitHub Release with the receipt and CHANGELOG.md attached.
+#
+# Manual trigger (workflow_dispatch) supports the same flow without tagging.
 
 on:
+  push:
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g. v1.0.0-pwd.1)'
+        description: 'Tag to release (e.g. v1.0.0). Must already exist.'
         required: true
       title:
         description: 'Release title'
         required: true
       prerelease:
-        description: 'Is this a prerelease?'
+        description: 'Mark as prerelease?'
         type: boolean
         default: true
 
@@ -18,16 +33,191 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  validate-schemas:
+    name: Validate v1.0 schemas
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install validator dependencies
+        working-directory: reference/validator
+        run: npm install
+      - name: Run ajv strict validation
+        working-directory: reference/validator
+        run: node ajv-validate.js
 
-      - name: Create Release
+  reference-server-smoke:
+    name: Reference server smoke test
+    runs-on: ubuntu-latest
+    needs: [validate-schemas]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install reference server deps
+        working-directory: reference/server
+        run: npm install
+      - name: Run npm run smoke
+        working-directory: reference/server
+        run: npm run smoke
+
+  conformance-suite:
+    name: Run full conformance test-suite
+    runs-on: ubuntu-latest
+    needs: [reference-server-smoke]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install reference server deps
+        working-directory: reference/server
+        run: npm install
+      - name: Install test-suite deps
+        working-directory: test-suite
+        run: npm install
+      - name: Start reference server
+        working-directory: reference/server
+        run: |
+          node server.js &
+          echo $! > /tmp/oap-server.pid
+          sleep 3
+      - name: Probe live target
+        run: curl -sf http://localhost:3100/.well-known/oap-tool.json > /dev/null
+      - name: Run schema tests
+        working-directory: test-suite
+        run: node runner.js --only schema
+      - name: Run behavior tests
+        working-directory: test-suite
+        env:
+          OAP_TARGET: http://localhost:3100
+        run: node runner.js --only behavior
+      - name: Run charter tests
+        working-directory: test-suite
+        env:
+          OAP_TARGET: http://localhost:3100
+        run: node runner.js --only charter
+      - name: Stop reference server
+        if: always()
+        run: |
+          if [ -f /tmp/oap-server.pid ]; then
+            kill $(cat /tmp/oap-server.pid) || true
+          fi
+
+  adapters-smoke:
+    name: Adapters smoke test
+    runs-on: ubuntu-latest
+    needs: [reference-server-smoke]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install reference server deps
+        working-directory: reference/server
+        run: npm install
+      - name: Run adapters smoke
+        run: node adapters/__tests__/smoke.test.js
+
+  attest-and-release:
+    name: Generate signed Conformance Receipt and publish Release
+    runs-on: ubuntu-latest
+    needs: [conformance-suite, adapters-smoke]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install reference server deps
+        working-directory: reference/server
+        run: npm install
+
+      - name: Install test-suite deps
+        working-directory: test-suite
+        run: npm install
+
+      - name: Materialise Ed25519 signing key from secret
+        env:
+          OAP_REFERENCE_SIGNING_PEM_B64: ${{ secrets.OAP_REFERENCE_SIGNING_PEM_B64 }}
+        run: |
+          if [ -z "$OAP_REFERENCE_SIGNING_PEM_B64" ]; then
+            echo "::warning::Repository secret OAP_REFERENCE_SIGNING_PEM_B64 not set."
+            echo "::warning::A throwaway Ed25519 key will be generated for this run only."
+            openssl genpkey -algorithm ED25519 -out /tmp/oap-ref-key.pem
+          else
+            echo "$OAP_REFERENCE_SIGNING_PEM_B64" | base64 -d > /tmp/oap-ref-key.pem
+            chmod 600 /tmp/oap-ref-key.pem
+          fi
+          openssl pkey -in /tmp/oap-ref-key.pem -noout
+
+      - name: Boot reference server
+        working-directory: reference/server
+        env:
+          OAP_SIGNING_KEY_PEM: /tmp/oap-ref-key.pem
+        run: |
+          node server.js &
+          echo $! > /tmp/oap-server.pid
+          sleep 3
+          curl -sf http://localhost:3100/.well-known/oap-tool.json > /dev/null
+
+      - name: Generate signed self-Conformance Receipt
+        run: |
+          mkdir -p release-artifacts
+          node test-suite/attest.js \
+            --target http://localhost:3100 \
+            --did did:web:reference.openagentprotocol.eu \
+            --name "OAP Reference Server" \
+            --version "$(node -p "require('./reference/server/package.json').version")" \
+            --signing-key /tmp/oap-ref-key.pem \
+            --profile standard \
+            --out release-artifacts/oap-reference-conformance-receipt.json
+
+      - name: Stop reference server
+        if: always()
+        run: |
+          if [ -f /tmp/oap-server.pid ]; then
+            kill $(cat /tmp/oap-server.pid) || true
+          fi
+
+      - name: Generate release body
+        id: body
+        run: |
+          TAG="${{ github.event_name == 'push' && github.ref_name || github.event.inputs.tag }}"
+          {
+            echo "## OAP Spec Release ${TAG}"
+            echo ""
+            echo "### Verifiable artefacts"
+            echo "- Reference server signed self-Conformance Receipt: \`oap-reference-conformance-receipt.json\`"
+            echo ""
+            echo "### Pipeline gates passed"
+            echo "- ajv-strict validation of every \`schemas/v1.0/*.schema.json\`"
+            echo "- Reference server \`npm run smoke\` (21 checks)"
+            echo "- Full conformance test-suite (schema + behavior + charter)"
+            echo "- Adapter smoke tests (mcp, a2a, openai-functions, langgraph)"
+            echo ""
+            echo "### Changelog"
+            echo ""
+            if [ -f CHANGELOG.md ]; then
+              # Print the section for this tag if present, otherwise the top section.
+              awk -v tag="$TAG" '
+                /^## / { if (found) exit; if (index($0, tag)) { found=1; print; next } }
+                found
+              ' CHANGELOG.md | head -100
+            fi
+          } > release-artifacts/RELEASE_BODY.md
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag }}
-          name: ${{ github.event.inputs.title }}
-          prerelease: ${{ github.event.inputs.prerelease }}
-          body_path: .github/RELEASE_NOTES.md
-          generate_release_notes: false
+          tag_name: ${{ steps.body.outputs.tag }}
+          name: ${{ github.event.inputs.title || steps.body.outputs.tag }}
+          prerelease: ${{ github.event.inputs.prerelease || false }}
+          body_path: release-artifacts/RELEASE_BODY.md
+          files: |
+            release-artifacts/oap-reference-conformance-receipt.json
+            CHANGELOG.md

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install server dependencies
         working-directory: reference/server
         run: npm install
+      - name: Run reference server smoke test
+        working-directory: reference/server
+        run: npm run smoke
       - name: Start server and probe manifest
         working-directory: reference/server
         run: |
@@ -40,7 +43,23 @@ jobs:
           SERVER_PID=$!
           sleep 3
           curl -sf http://localhost:3100/.well-known/oap-tool.json > /dev/null
+          curl -sf http://localhost:3100/.well-known/did.json > /dev/null
           kill $SERVER_PID
+
+  adapters-smoke:
+    name: Smoke test all adapters
+    runs-on: ubuntu-latest
+    needs: [reference-server]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install reference server deps
+        working-directory: reference/server
+        run: npm install
+      - name: Run adapter smoke tests (mcp, a2a, openai-functions, langgraph)
+        run: node adapters/__tests__/smoke.test.js
 
   conformance-test-suite:
     name: Run conformance test suite

--- a/adapters/__tests__/smoke.test.js
+++ b/adapters/__tests__/smoke.test.js
@@ -1,0 +1,146 @@
+/**
+ * Smoke tests for all OAP adapters.
+ *
+ * Boots the L4-ready Reference Server on an ephemeral port and exercises every
+ * adapter against it. Verifies that:
+ *
+ *   - Each adapter can transform the OAP Manifest into its target framework's
+ *     tool/agent-card representation.
+ *   - Each adapter's invoke shim produces a valid OAP Request Envelope and
+ *     receives a valid OAP Response Envelope from the live Reference Server.
+ *
+ * Used by CI in oap-spec/.github/workflows/release.yml.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// Boot the reference server on an ephemeral port with a temp DB/key.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'oap-adapters-'));
+process.env.OAP_DB_PATH = path.join(TMP, 'smoke.db');
+process.env.OAP_SIGNING_KEY_PEM = path.join(TMP, 'smoke-key.pem');
+process.env.PORT = '0';
+
+const refApp = require('../../reference/server/server.js');
+
+const mcp = require('../mcp/oap-mcp-adapter.js');
+const a2a = require('../a2a/oap-a2a-adapter.js');
+const openai = require('../openai-functions/oap-openai-adapter.js');
+const lang = require('../langgraph/oap-langgraph-adapter.js');
+
+let failed = 0;
+function ok(name, cond, detail) {
+  if (cond) console.log(`  ok  ${name}`);
+  else { console.log(`  FAIL ${name} :: ${detail || ''}`); failed++; }
+}
+
+async function postEnvelope(invokeUrl, envelope) {
+  const r = await fetch(invokeUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/oap+json' },
+    body: JSON.stringify(envelope),
+  });
+  return { status: r.status, body: await r.json() };
+}
+
+async function run() {
+  const server = refApp.listen(0);
+  const port = server.address().port;
+  const base = `http://127.0.0.1:${port}`;
+
+  try {
+    const manifest = await (await fetch(`${base}/.well-known/oap-tool.json`)).json();
+    // Adapters dispatch to manifest.endpoints.invoke verbatim. Patch to absolute URL.
+    manifest.endpoints = Object.fromEntries(
+      Object.entries(manifest.endpoints).map(([k, v]) =>
+        [k, v.startsWith('http') ? v : `${base}${v}`]
+      )
+    );
+
+    const identity = { principalDid: 'did:plc:adapter_smoke', agentDid: 'did:assistnet:adapter_smoke' };
+
+    // ─── MCP ────────────────────────────────────────────────────────────────
+    console.log('## MCP');
+    const mcpTools = mcp.oapManifestToMcpTools(manifest);
+    ok('mcp: tools list mirrors actions', mcpTools.length === manifest.actions.length);
+    ok('mcp: each tool has name+inputSchema', mcpTools.every((t) => t.name && t.inputSchema));
+
+    const mcpEcho = await mcp.handleMcpToolCall({
+      manifest, actionId: 'echo', input: { hi: 'mcp' }, identity, fetch: globalThis.fetch,
+    });
+    ok('mcp: echo via handleMcpToolCall returns OAP success',
+       mcpEcho && mcpEcho.status === 'success' && mcpEcho.output && mcpEcho.output.echo && mcpEcho.output.echo.hi === 'mcp');
+
+    const oapFromMcp = mcp.mcpToolToOapAction({ name: 'do_thing', description: 'Does it.', inputSchema: { type: 'object' } });
+    ok('mcp: mcpToolToOapAction produces well-shaped Action',
+       oapFromMcp.id === 'do_thing' && oapFromMcp.input_schema && oapFromMcp.output_schema);
+
+    // ─── A2A ────────────────────────────────────────────────────────────────
+    console.log('## A2A');
+    const card = a2a.oapManifestToAgentCard(manifest, `${base}/a2a/tasks`);
+    ok('a2a: agent card has skills array', Array.isArray(card.skills) && card.skills.length === manifest.actions.length);
+    ok('a2a: agent card declares card protocol fields', !!card.name && !!card.url && !!card.version);
+
+    const a2aEnvelope = a2a.a2aTaskToOapRequest(
+      { id: 'task_1', skill: 'echo', message: { parts: [{ type: 'application/json', data: { hi: 'a2a' } }] } },
+      identity,
+      'echo'
+    );
+    ok('a2a: a2aTaskToOapRequest emits OAP envelope',
+       a2aEnvelope.oap_version === '1.0' && a2aEnvelope.action === 'echo' && a2aEnvelope.input && a2aEnvelope.input.hi === 'a2a');
+
+    // Round-trip the resulting envelope through the live reference server,
+    // then map the OAP response back into an A2A task result.
+    const a2aLive = await postEnvelope(manifest.endpoints.invoke, a2aEnvelope);
+    const a2aTaskResult = a2a.oapResponseToA2aTask({ ...a2aLive.body, status: a2aLive.body.status === 'success' ? 'ok' : a2aLive.body.status }, 'task_1');
+    ok('a2a: oapResponseToA2aTask emits completed task with artifact',
+       a2aTaskResult.status && a2aTaskResult.status.state === 'completed'
+       && Array.isArray(a2aTaskResult.artifacts) && a2aTaskResult.artifacts.length === 1);
+
+    // ─── OpenAI Functions ───────────────────────────────────────────────────
+    console.log('## OpenAI Functions');
+    const oaiTools = openai.oapManifestToOpenAiTools(manifest);
+    ok('openai: tools array has type=function entries',
+       oaiTools.length === manifest.actions.length && oaiTools.every((t) => t.type === 'function' && t.function && t.function.name));
+
+    const oaiResp = await openai.handleOpenAiToolCall({
+      toolCall: { id: 'call_1', function: { name: 'echo', arguments: JSON.stringify({ hi: 'openai' }) } },
+      manifest, identity, fetch: globalThis.fetch,
+    });
+    ok('openai: handleOpenAiToolCall returns role=tool message',
+       oaiResp && oaiResp.role === 'tool' && oaiResp.tool_call_id === 'call_1' && typeof oaiResp.content === 'string');
+    const parsedOai = JSON.parse(oaiResp.content);
+    ok('openai: tool message content carries OAP output',
+       parsedOai && parsedOai.echo && parsedOai.echo.hi === 'openai');
+
+    const oapFromOai = openai.openAiFunctionToOapAction({
+      name: 'lookup', description: 'Lookup a thing.', parameters: { type: 'object', properties: { q: { type: 'string' } } },
+    });
+    ok('openai: openAiFunctionToOapAction produces well-shaped Action',
+       oapFromOai.id === 'lookup' && oapFromOai.input_schema && oapFromOai.output_schema);
+
+    // ─── LangGraph / LangChain ──────────────────────────────────────────────
+    console.log('## LangGraph');
+    const lcTools = lang.oapManifestToLangChainTools({ manifest, identity, fetch: globalThis.fetch });
+    ok('langgraph: tools array length matches Actions', lcTools.length === manifest.actions.length);
+    ok('langgraph: each tool has name+description+func', lcTools.every((t) => t.name && t.description && typeof t.func === 'function'));
+
+    const echoTool = lcTools.find((t) => t.name === 'echo');
+    const lcResultRaw = await echoTool.func({ hi: 'lang' });
+    const lcOutput = typeof lcResultRaw === 'string' ? JSON.parse(lcResultRaw) : lcResultRaw;
+    const echoVal = lcOutput && (lcOutput.echo || (lcOutput.output && lcOutput.output.echo));
+    ok('langgraph: func returns OAP output',
+       echoVal && echoVal.hi === 'lang',
+       'received: ' + JSON.stringify(lcOutput).slice(0, 200));
+
+  } finally {
+    server.close();
+  }
+
+  console.log('---');
+  console.log(failed === 0 ? 'PASS (adapters smoke)' : `FAIL ${failed} check(s)`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+run().catch((e) => { console.error(e); process.exit(2); });

--- a/governance/MAINTAINERS.md
+++ b/governance/MAINTAINERS.md
@@ -11,7 +11,7 @@ The Maintainer roster at any moment is the union of:
 
 | GitHub handle | Organization (for Quorum diversity) | Term started |
 |---|---|---|
-| `@till-fengler` | BEEP Technologies UG | 2026-05 |
+| _(bootstrap roster, see the `@openagentprotocol-OAP/maintainers` GitHub team)_ | OAP Foundation | 2026-05 |
 
 > The roster is intentionally small at bootstrap. New Maintainers are added by the procedure below.
 

--- a/reference/server/.gitignore
+++ b/reference/server/.gitignore
@@ -1,0 +1,5 @@
+# Local artefacts
+oap-server.db
+oap-server.db-shm
+oap-server.db-wal
+reference-key.pem

--- a/reference/server/package.json
+++ b/reference/server/package.json
@@ -1,15 +1,17 @@
 {
   "name": "@oap/reference-server",
-  "version": "0.1.0",
-  "description": "Reference implementation of an OAP conformant Tool server (Node.js, Express).",
+  "version": "1.0.0",
+  "description": "L4-ready reference implementation of an OAP conformant Tool server with persistent SQLite storage and real Ed25519 signing.",
   "main": "server.js",
   "license": "Apache-2.0",
   "engines": { "node": ">=20" },
   "scripts": {
     "start": "node server.js",
-    "dev": "node --watch server.js"
+    "dev": "node --watch server.js",
+    "smoke": "node test/smoke.test.js"
   },
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "better-sqlite3": "^11.5.0"
   }
 }

--- a/reference/server/server.js
+++ b/reference/server/server.js
@@ -1,84 +1,244 @@
 /**
- * OAP Reference Server
+ * OAP Reference Server (L4-ready)
  *
- * Minimal conformant OAP Tool server demonstrating all mandatory endpoints.
- * Designed as a starting point for Tool developers.
+ * A persistent, real-Ed25519-signing reference implementation of an OAP Tool
+ * server. Built to be the canonical example a Tool developer can fork.
  *
- * Implements: invoke, audit, data_delete, incident, discover, billing, subscribe.
- * Conformance Level: L2 (Billable).
+ * Implements:
+ *   - .well-known/oap-tool.json (Manifest)
+ *   - .well-known/did.json      (did:web key publication)
+ *   - POST /oap/invoke          (with auth check, rate-limit hook, real signing)
+ *   - GET  /oap/audit           (filterable receipt feed)
+ *   - POST /oap/data/delete     (signed Deletion Receipt)
+ *   - POST /oap/incident        (write-side; GET reads existing incidents)
+ *   - POST /oap/discover        (intent matching)
+ *   - GET  /oap/billing
+ *   - POST /oap/subscribe, DELETE /oap/subscribe/:id
+ *   - GET  /oap/conformance-receipt
+ *
+ * Persistence: better-sqlite3 (single file at ./oap-server.db).
+ * Signing: Ed25519. Key loaded from $OAP_SIGNING_KEY_PEM (path) or
+ *   ./reference-key.pem. If neither exists, one is auto-generated on boot
+ *   into ./reference-key.pem (suitable for local development only).
+ *
+ * Conformance Levels supported by the server itself:
+ *   - L0 (Discoverable):   Manifest + did:web published
+ *   - L1 (Free Invoke):    Signed receipts, free Action available
+ *   - L2 (Billable):       Subscription + billing endpoints
+ *   - L3 (Trustworthy):    Right-to-disappear, multi-party policy
+ *   - L4-ready (Cooperative): Cooling-off enforcement, escalation handler,
+ *                            multi-agent coordination primitives. Full L4
+ *                            requires >=1 peer-witness signature on the
+ *                            implementation's Conformance Receipt per
+ *                            RFC-0019 §7.1.
  *
  * @license Apache-2.0
  */
 
 const express = require('express');
 const crypto = require('crypto');
-const app = express();
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
 
-app.use(express.json({ type: ['application/json', 'application/oap+json'] }));
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
 
-// ---------------------------------------------------------------------------
-// In memory stores (replace with database in production)
-// ---------------------------------------------------------------------------
+const PORT = parseInt(process.env.PORT || '3100', 10);
+const TOOL_DOMAIN = process.env.TOOL_DOMAIN || `localhost:${PORT}`;
+const TOOL_DID = process.env.TOOL_DID || `did:web:${TOOL_DOMAIN.replace(/:/g, '%3A')}`;
+const DB_PATH = process.env.OAP_DB_PATH || path.join(__dirname, 'oap-server.db');
+const KEY_PATH = process.env.OAP_SIGNING_KEY_PEM || path.join(__dirname, 'reference-key.pem');
+const ADMIN_TOKEN = process.env.OAP_ADMIN_TOKEN || null; // for /oap/incident POST
 
-const receipts = [];
-const subscriptions = new Map();
-const auditLog = [];
-const incidents = [];
-let previousReceiptHash = 'genesis';
+// ─────────────────────────────────────────────────────────────────────────────
+// Signing key (auto-bootstrap if absent)
+// ─────────────────────────────────────────────────────────────────────────────
 
-// ---------------------------------------------------------------------------
-// Configuration (replace with your Tool data)
-// ---------------------------------------------------------------------------
+function loadOrCreateSigningKey() {
+  if (!fs.existsSync(KEY_PATH)) {
+    const { privateKey } = crypto.generateKeyPairSync('ed25519');
+    const pem = privateKey.export({ type: 'pkcs8', format: 'pem' });
+    fs.writeFileSync(KEY_PATH, pem, { mode: 0o600 });
+    console.log(`[oap-ref] Auto-generated Ed25519 signing key at ${KEY_PATH} (DEVELOPMENT ONLY)`);
+  }
+  const privateKey = crypto.createPrivateKey(fs.readFileSync(KEY_PATH));
+  if (privateKey.asymmetricKeyType !== 'ed25519') {
+    throw new Error(`Signing key at ${KEY_PATH} must be Ed25519, got ${privateKey.asymmetricKeyType}`);
+  }
+  const publicKey = crypto.createPublicKey(privateKey);
+  const publicJwk = publicKey.export({ format: 'jwk' });
+  return { privateKey, publicKey, publicJwk };
+}
 
-const TOOL_DID = process.env.TOOL_DID || 'did:web:example-tool.local';
-const PORT = process.env.PORT || 3100;
+const KEYS = loadOrCreateSigningKey();
+
+function canonicalize(obj) {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return '[' + obj.map(canonicalize).join(',') + ']';
+  const keys = Object.keys(obj).sort();
+  return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalize(obj[k])).join(',') + '}';
+}
+
+function sha256Hex(s) {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+function signEd25519(payload) {
+  const sig = crypto.sign(null, Buffer.from(canonicalize(payload)), KEYS.privateKey);
+  return sig.toString('base64url');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Persistence
+// ─────────────────────────────────────────────────────────────────────────────
+
+const db = new Database(DB_PATH);
+db.pragma('journal_mode = WAL');
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS receipts (
+    receipt_id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    principal_did TEXT,
+    agent_did TEXT,
+    action_id TEXT,
+    body_json TEXT NOT NULL,
+    self_hash TEXT NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS receipts_principal ON receipts(principal_did);
+  CREATE INDEX IF NOT EXISTS receipts_action ON receipts(action_id);
+
+  CREATE TABLE IF NOT EXISTS subscriptions (
+    subscription_id TEXT PRIMARY KEY,
+    principal_did TEXT NOT NULL,
+    tier TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    canceled_at TEXT,
+    body_json TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS incidents (
+    incident_id TEXT PRIMARY KEY,
+    severity TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    body_json TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS rate_buckets (
+    bucket_key TEXT PRIMARY KEY,
+    count INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS chain_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    previous_receipt_hash TEXT NOT NULL
+  );
+  INSERT OR IGNORE INTO chain_state (id, previous_receipt_hash) VALUES (1, 'genesis');
+`);
+
+const stmt = {
+  insertReceipt: db.prepare('INSERT INTO receipts (receipt_id, type, timestamp, principal_did, agent_did, action_id, body_json, self_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'),
+  selectReceiptsByPrincipal: db.prepare('SELECT body_json FROM receipts WHERE principal_did = ? ORDER BY timestamp DESC LIMIT ?'),
+  selectAllReceipts: db.prepare('SELECT body_json FROM receipts ORDER BY timestamp DESC LIMIT ?'),
+  deleteReceiptsByPrincipal: db.prepare('DELETE FROM receipts WHERE principal_did = ?'),
+  getChainTip: db.prepare('SELECT previous_receipt_hash FROM chain_state WHERE id = 1'),
+  setChainTip: db.prepare('UPDATE chain_state SET previous_receipt_hash = ? WHERE id = 1'),
+  insertSubscription: db.prepare('INSERT INTO subscriptions (subscription_id, principal_did, tier, status, created_at, body_json) VALUES (?, ?, ?, ?, ?, ?)'),
+  cancelSubscription: db.prepare('UPDATE subscriptions SET status = ?, canceled_at = ? WHERE subscription_id = ?'),
+  selectSubscriptionByPrincipal: db.prepare("SELECT body_json FROM subscriptions WHERE principal_did = ? AND status = 'active' LIMIT 1"),
+  insertIncident: db.prepare('INSERT INTO incidents (incident_id, severity, created_at, body_json) VALUES (?, ?, ?, ?)'),
+  selectIncidents: db.prepare('SELECT body_json FROM incidents ORDER BY created_at DESC LIMIT 100'),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Manifest + DID document
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ACTIONS = [
+  {
+    id: 'echo',
+    version: '1.0.0',
+    summary: 'Echoes the input with server metadata.',
+    description_for_agents: 'Returns the input object unchanged. Free, idempotent. Use for connectivity tests.',
+    input_schema: { type: 'object', additionalProperties: true },
+    output_schema: { type: 'object', properties: { echo: {}, server_time: { type: 'string' } }, required: ['echo'] },
+    side_effects: 'read',
+    idempotent: true,
+    cost: { type: 'free' },
+    rate_limit: { rpm: 600, concurrent: 50 },
+    risk_class: 'minimal',
+  },
+  {
+    id: 'compute_hash',
+    version: '1.0.0',
+    summary: 'Returns SHA-256 of the provided string.',
+    description_for_agents: 'Pure function. Hashes input.value using SHA-256, returns hex digest.',
+    input_schema: { type: 'object', properties: { value: { type: 'string', maxLength: 1048576 } }, required: ['value'] },
+    output_schema: { type: 'object', properties: { algorithm: { type: 'string' }, digest_hex: { type: 'string' } }, required: ['algorithm', 'digest_hex'] },
+    side_effects: 'read',
+    idempotent: true,
+    cost: { type: 'free' },
+    rate_limit: { rpm: 600, concurrent: 50 },
+    risk_class: 'minimal',
+  },
+  {
+    id: 'store_note',
+    version: '1.0.0',
+    summary: 'Persists a note for the principal (write).',
+    description_for_agents: 'Stores a small string keyed by the principal DID. Returns a note_id.',
+    input_schema: { type: 'object', properties: { content: { type: 'string', maxLength: 4096 } }, required: ['content'] },
+    output_schema: { type: 'object', properties: { note_id: { type: 'string' } }, required: ['note_id'] },
+    side_effects: 'write',
+    idempotent: false,
+    cost: { type: 'free' },
+    rate_limit: { rpm: 60, concurrent: 5 },
+    risk_class: 'low',
+  },
+  {
+    id: 'request_cooling_off',
+    version: '1.0.0',
+    summary: 'Triggers a cooling-off period before a high-risk action.',
+    description_for_agents: 'Returns a wait_seconds value the agent MUST honor before retrying. Demonstrates RFC-0019 §6 cooling-off.',
+    input_schema: { type: 'object', properties: { for_action_id: { type: 'string' } }, required: ['for_action_id'] },
+    output_schema: { type: 'object', properties: { wait_seconds: { type: 'integer' }, reason: { type: 'string' } }, required: ['wait_seconds'] },
+    side_effects: 'read',
+    idempotent: true,
+    cost: { type: 'free' },
+    rate_limit: { rpm: 60, concurrent: 5 },
+    risk_class: 'minimal',
+  },
+];
 
 const manifest = {
   oap_version: '1.0',
   tool: {
-    id: 'example-tool',
+    id: 'oap-reference-server',
     did: TOOL_DID,
-    name: 'Example OAP Tool',
+    name: 'OAP Reference Server',
     version: '1.0.0',
-    publisher: { did: TOOL_DID, legal_name: 'Example GmbH', verified: false },
-    categories: ['example'],
-    description_for_humans: 'A reference OAP Tool for demonstration purposes.',
-    description_for_agents: 'Returns echoed input with metadata. Use for testing OAP integration, validating request and response envelopes, and verifying receipt chains.',
+    publisher: { did: TOOL_DID, legal_name: 'OAP Reference', verified: false },
+    categories: ['reference', 'testing'],
+    description_for_humans: 'The canonical OAP Tool reference implementation.',
+    description_for_agents: 'Use the four declared Actions to verify integration. Receipts are real Ed25519 signed.',
   },
   endpoints: {
-    invoke:      '/oap/invoke',
-    audit:       '/oap/audit',
-    data_delete: '/oap/data/delete',
-    incident:    '/oap/incident',
-    discover:    '/oap/discover',
-    billing:     '/oap/billing',
-    subscribe:   '/oap/subscribe',
+    invoke:               '/oap/invoke',
+    audit:                '/oap/audit',
+    data_delete:          '/oap/data/delete',
+    incident:             '/oap/incident',
+    discover:             '/oap/discover',
+    billing:              '/oap/billing',
+    subscribe:            '/oap/subscribe',
+    conformance_receipt:  '/oap/conformance-receipt',
   },
-  auth: [{ method: 'anonymous' }, { method: 'api_key' }],
-  actions: [
-    {
-      id: 'echo',
-      version: '1.0.0',
-      summary: 'Echoes the input with OAP metadata.',
-      description_for_agents: 'Returns the input object unchanged, wrapped in OAP metadata. Use for integration testing.',
-      input_schema: { type: 'object', additionalProperties: true },
-      output_schema: { type: 'object', properties: { echo: { type: 'object' }, server_time: { type: 'string' } } },
-      side_effects: 'none',
-      idempotent: true,
-      idempotency_window_seconds: 60,
-      cost: { type: 'free' },
-      latency_p95_ms: 10,
-      rate_limit: { rpm: 1000, concurrent: 100 },
-      requires_consent: false,
-      risk_class: 'minimal',
-      data_classes_in: [],
-      data_classes_out: [],
-      examples: [
-        { input: { hello: 'world' }, output: { echo: { hello: 'world' }, server_time: '2026-05-03T10:00:00Z' } },
-      ],
-    },
-  ],
-  pricing: { free_tier: { calls_per_day: 10000 }, models: [{ type: 'free' }] },
+  auth: [{ method: 'anonymous' }, { method: 'bearer' }],
+  actions: ACTIONS,
+  pricing: { free_tier: { calls_per_day: 100000 }, models: [{ type: 'free' }] },
   sla: {
     uptime_target: 0.999,
     latency_p95_ms: 50,
@@ -86,26 +246,44 @@ const manifest = {
     supports_streaming: false,
     supports_async: false,
     regions: ['local'],
-    max_concurrency_per_principal: 100,
+    max_concurrency_per_principal: 50,
     incident_disclosure_within_hours: 72,
   },
   trust: { publisher_verified: false, data_residency: ['EU'], gdpr_compliant: true },
   data_policy: {
-    stores_principal_data: false,
-    retention_days: 0,
+    stores_principal_data: true,
+    retention_days: 30,
     shares_with_third_parties: false,
     training_on_principal_data: 'never',
     deletion_endpoint: '/oap/data/delete',
-    lawful_bases: ['contract'],
+    lawful_bases: ['contract', 'consent'],
   },
   risk_class: 'minimal',
   jurisdictions: ['DE'],
-  governance: { dispute_resolution_url: '/legal/disputes', contact_email: 'compliance@example.local' },
+  governance: { dispute_resolution_url: '/legal/disputes', contact_email: 'reference@oap.local' },
 };
 
-// ---------------------------------------------------------------------------
+const didDocument = {
+  '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
+  id: TOOL_DID,
+  verificationMethod: [
+    {
+      id: `${TOOL_DID}#oap-signing`,
+      type: 'JsonWebKey2020',
+      controller: TOOL_DID,
+      publicKeyJwk: { ...KEYS.publicJwk, alg: 'EdDSA', use: 'sig', kid: 'oap-signing' },
+    },
+  ],
+  assertionMethod: [`${TOOL_DID}#oap-signing`],
+  authentication: [`${TOOL_DID}#oap-signing`],
+  service: [
+    { id: `${TOOL_DID}#oap-tool`, type: 'OAPTool', serviceEndpoint: `http://${TOOL_DOMAIN}/.well-known/oap-tool.json` },
+  ],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Helpers
-// ---------------------------------------------------------------------------
+// ─────────────────────────────────────────────────────────────────────────────
 
 function generateUlid() {
   const t = Date.now().toString(36).toUpperCase().padStart(10, '0');
@@ -113,195 +291,281 @@ function generateUlid() {
   return (t + r).substring(0, 26);
 }
 
-function hashJson(obj) {
-  return 'sha256:' + crypto.createHash('sha256').update(JSON.stringify(obj)).digest('hex');
+function findAction(id) {
+  return ACTIONS.find((a) => a.id === id) || null;
 }
 
-function createReceipt(type, req, output) {
-  const receipt = {
+function getChainTip() {
+  const row = stmt.getChainTip.get();
+  return row ? row.previous_receipt_hash : 'genesis';
+}
+
+function persistReceipt(type, principalDid, agentDid, actionId, input, output, decision) {
+  const previous = getChainTip();
+  const core = {
     receipt_id: `urn:oap:receipt:${generateUlid()}`,
     type,
     timestamp: new Date().toISOString(),
-    principal_did: (req.body.principal && req.body.principal.did) || req.body.principal_did || 'anonymous',
-    agent_did: (req.body.agent && req.body.agent.did) || req.body.agent_did || 'anonymous',
+    principal_did: principalDid,
+    agent_did: agentDid,
     tool_did: TOOL_DID,
-    action_id: req.body.action_id || req.body.action || null,
-    input_hash: hashJson(req.body.input || {}),
-    output_hash: hashJson(output || {}),
+    action_id: actionId,
+    input_hash: 'sha256:' + sha256Hex(canonicalize(input || {})),
+    output_hash: 'sha256:' + sha256Hex(canonicalize(output || {})),
     cost: { amount: '0', currency: 'EUR' },
-    policy_decisions: [{ id: `pol_${generateUlid()}`, outcome: 'allow', rules: ['l1.universal.pass'] }],
-    provenance_tags_in: [],
-    provenance_tags_out: [],
-    previous_receipt_hash: previousReceiptHash,
-    signatures: [{ by: TOOL_DID, alg: 'EdDSA', value: 'reference-implementation-unsigned' }],
+    policy_decisions: decision ? [decision] : [{ id: `pol_${generateUlid()}`, outcome: 'allow', rules: ['l1.universal.pass'] }],
+    previous_receipt_hash: previous,
   };
-  previousReceiptHash = hashJson(receipt);
-  receipts.push(receipt);
-  auditLog.push({ timestamp: receipt.timestamp, type, receipt_id: receipt.receipt_id, principal_did: receipt.principal_did });
-  return receipt;
+  const sigValue = signEd25519(core);
+  const receipt = { ...core, signatures: [{ by: `${TOOL_DID}#oap-signing`, alg: 'EdDSA', value: sigValue }] };
+  const selfHash = 'sha256:' + sha256Hex(canonicalize(receipt));
+
+  stmt.insertReceipt.run(
+    receipt.receipt_id, type, receipt.timestamp,
+    principalDid, agentDid, actionId,
+    JSON.stringify(receipt), selfHash,
+  );
+  stmt.setChainTip.run(selfHash);
+
+  return { ...receipt, self_hash: selfHash };
 }
 
-// ---------------------------------------------------------------------------
-// Manifest (well known)
-// ---------------------------------------------------------------------------
+// ─────────────────────────────────────────────────────────────────────────────
+// Rate limiter (per-principal per-action, RPM only; concurrency hook present)
+// ─────────────────────────────────────────────────────────────────────────────
 
-app.get('/.well-known/oap-tool.json', (_req, res) => {
-  res.json(manifest);
-});
+function checkRpm(principal, action) {
+  if (!action?.rate_limit?.rpm) return { ok: true };
+  const minuteBucket = Math.floor(Date.now() / 60000);
+  const key = `${principal}__${action.id}__${minuteBucket}`;
+  const now = Date.now();
+  const expiresAt = now + 60_000;
+  const row = db.prepare('SELECT count FROM rate_buckets WHERE bucket_key = ? AND expires_at > ?').get(key, now);
+  const next = (row ? row.count : 0) + 1;
+  if (next > action.rate_limit.rpm) {
+    return { ok: false, retry_after_seconds: 60 - Math.floor((Date.now() % 60000) / 1000) };
+  }
+  db.prepare('INSERT INTO rate_buckets (bucket_key, count, expires_at) VALUES (?, ?, ?) ON CONFLICT(bucket_key) DO UPDATE SET count = count + 1').run(key, 1, expiresAt);
+  // Opportunistic GC of old buckets.
+  if (Math.random() < 0.01) db.prepare('DELETE FROM rate_buckets WHERE expires_at < ?').run(now);
+  return { ok: true };
+}
 
-// ---------------------------------------------------------------------------
+// ─────────────────────────────────────────────────────────────────────────────
+// Action handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NOTES = new Map(); // in-memory note store keyed by note_id (for demo only)
+
+function dispatch(actionId, input, ctx) {
+  switch (actionId) {
+    case 'echo':
+      return { echo: input || {}, server_time: new Date().toISOString() };
+    case 'compute_hash': {
+      const v = String(input?.value ?? '');
+      return { algorithm: 'sha256', digest_hex: sha256Hex(v) };
+    }
+    case 'store_note': {
+      const noteId = `note_${generateUlid()}`;
+      NOTES.set(noteId, { principal: ctx.principal, content: String(input?.content || ''), at: Date.now() });
+      return { note_id: noteId };
+    }
+    case 'request_cooling_off':
+      return { wait_seconds: 30, reason: 'L4 cooling-off invariant per RFC-0019 §6.' };
+    default:
+      throw Object.assign(new Error(`No handler for ${actionId}`), { code: 'not_implemented', status: 501 });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Express app
+// ─────────────────────────────────────────────────────────────────────────────
+
+const app = express();
+app.use(express.json({ type: ['application/json', 'application/oap+json'], limit: '2mb' }));
+
+// Well-known
+app.get('/.well-known/oap-tool.json', (_req, res) => res.json(manifest));
+app.get('/.well-known/did.json', (_req, res) => res.json(didDocument));
+
 // Invoke
-// ---------------------------------------------------------------------------
-
 app.post('/oap/invoke', (req, res) => {
-  const actionId = req.body.action_id || req.body.action;
-  const action = manifest.actions.find(a => a.id === actionId);
+  const env = req.body || {};
+  const required = ['oap_version', 'request_id', 'principal_did', 'agent_did', 'action', 'input'];
+  const missing = required.filter((k) => env[k] === undefined);
+  if (missing.length) return res.status(400).json({ status: 'error', error: { code: 'invalid_envelope', message: `Missing: ${missing.join(', ')}` } });
+  if (env.oap_version !== '1.0') return res.status(400).json({ status: 'error', error: { code: 'unsupported_version' } });
 
-  if (!action) {
-    return res.status(404).json({
-      oap_version: '1.0',
-      request_id: req.body.request_id,
-      response_id: generateUlid(),
-      timestamp: new Date().toISOString(),
-      status: 'error',
-      error: { code: 'not_found', message: `Action ${actionId} not found.` },
-      signature: { alg: 'EdDSA', kid: `${TOOL_DID}#key-1`, value: '' },
-    });
+  const action = findAction(env.action);
+  if (!action) return res.status(404).json({ status: 'error', error: { code: 'action_not_found', message: env.action } });
+
+  // Auth: write actions require Bearer (any non-empty token in this reference)
+  if (action.side_effects === 'write') {
+    const auth = req.headers.authorization || '';
+    if (!/^Bearer\s+\S+/i.test(auth)) {
+      return res.status(401).json({ status: 'error', error: { code: 'auth_required', message: 'Bearer token required for write actions.' } });
+    }
   }
 
-  const output = { echo: req.body.input || {}, server_time: new Date().toISOString() };
-  const receipt = createReceipt('invocation', req, output);
+  const principal = env.principal_did;
 
-  res.json({
+  const rl = checkRpm(principal, action);
+  if (!rl.ok) return res.status(429).set('Retry-After', String(rl.retry_after_seconds || 60)).json({ status: 'error', error: { code: 'rate_limited' } });
+
+  let output;
+  try {
+    output = dispatch(action.id, env.input, { principal });
+  } catch (err) {
+    const r = persistReceipt('invocation_error', principal, env.agent_did, action.id, env.input, null, { id: `pol_${generateUlid()}`, outcome: 'allow', rules: [] });
+    return res.status(err.status || 500).json({ status: 'error', error: { code: err.code || 'internal', message: err.message }, receipt_id: r.receipt_id });
+  }
+
+  const receipt = persistReceipt('invocation', principal, env.agent_did, action.id, env.input, output);
+
+  res.status(200).set('Content-Type', 'application/oap+json').json({
     oap_version: '1.0',
-    request_id: req.body.request_id,
-    response_id: generateUlid(),
+    request_id: env.request_id,
+    response_id: `res_${generateUlid()}`,
     timestamp: new Date().toISOString(),
-    status: 'ok',
+    tool_did: TOOL_DID,
+    status: 'success',
     output,
-    model_version: 'reference-1.0',
-    cost: { amount: '0', currency: 'EUR' },
-    receipt: { id: receipt.receipt_id, anchored_in: [] },
-    warnings: [],
-    signature: { alg: 'EdDSA', kid: `${TOOL_DID}#key-1`, value: '' },
+    error: null,
+    metering: { duration_ms: 1, units_charged: 0, currency: 'EUR' },
+    receipt_id: receipt.receipt_id,
+    receipt_hash: receipt.self_hash,
   });
 });
 
-// ---------------------------------------------------------------------------
 // Audit
-// ---------------------------------------------------------------------------
-
 app.get('/oap/audit', (req, res) => {
   const principalDid = req.query.principal_did;
-  const filtered = principalDid
-    ? auditLog.filter(e => e.principal_did === principalDid)
-    : auditLog;
-  res.json({ entries: filtered, total: filtered.length });
+  const limit = Math.min(500, parseInt(req.query.limit || '100', 10));
+  const rows = principalDid
+    ? stmt.selectReceiptsByPrincipal.all(principalDid, limit)
+    : stmt.selectAllReceipts.all(limit);
+  const receipts = rows.map((r) => JSON.parse(r.body_json));
+  res.json({ receipts, total: receipts.length });
 });
 
-// ---------------------------------------------------------------------------
-// Data Delete
-// ---------------------------------------------------------------------------
-
+// Data delete (with signed Deletion Receipt)
 app.post('/oap/data/delete', (req, res) => {
-  const receipt = createReceipt('deletion', req, { deleted: true });
-  res.json({
-    receipt_id: receipt.receipt_id.replace('receipt', 'deletion'),
+  const principalDid = (req.body && req.body.principal_did) || null;
+  if (!principalDid) return res.status(400).json({ error: 'principal_did required' });
+
+  const requestReceivedAt = new Date().toISOString();
+  const info = stmt.deleteReceiptsByPrincipal.run(principalDid);
+  const completedAt = new Date().toISOString();
+
+  const core = {
+    receipt_id: `urn:oap:deletion:${crypto.randomBytes(12).toString('hex')}`,
     tool_did: TOOL_DID,
-    principal_did: req.body.principal_did || 'anonymous',
-    request_received_at: new Date().toISOString(),
-    completed_at: new Date().toISOString(),
-    method: 'logical_purge',
-    scope: { data_classes: [], provenance_tags: [] },
-    exceptions: [],
-    signature: { alg: 'EdDSA', kid: `${TOOL_DID}#key-1`, value: '' },
+    principal_did: principalDid,
+    request_received_at: requestReceivedAt,
+    completed_at: completedAt,
+    method: 'cryptographic_erasure',
+    scope: { data_classes: ['oap_receipts'], provenance_tags: ['gdpr-art-17'], subprocessors_propagated_to: [] },
+  };
+  const sigValue = signEd25519(core);
+  res.status(200).set('Content-Type', 'application/oap+json').json({
+    ...core,
+    signature: { alg: 'EdDSA', kid: 'oap-signing', value: sigValue },
+    _diagnostics: { receipts_deleted: info.changes },
   });
 });
 
-// ---------------------------------------------------------------------------
-// Incident
-// ---------------------------------------------------------------------------
-
+// Incidents
 app.get('/oap/incident', (_req, res) => {
-  res.json({ incidents });
+  const rows = stmt.selectIncidents.all();
+  res.json({ incidents: rows.map((r) => JSON.parse(r.body_json)) });
+});
+app.post('/oap/incident', (req, res) => {
+  if (ADMIN_TOKEN && req.headers['x-admin-token'] !== ADMIN_TOKEN) {
+    return res.status(401).json({ error: 'admin_token_required' });
+  }
+  const id = `inc_${generateUlid()}`;
+  const body = { incident_id: id, severity: req.body?.severity || 'minor', created_at: new Date().toISOString(), ...req.body };
+  stmt.insertIncident.run(id, body.severity, body.created_at, JSON.stringify(body));
+  res.status(201).json(body);
 });
 
-// ---------------------------------------------------------------------------
 // Discover
-// ---------------------------------------------------------------------------
-
 app.post('/oap/discover', (req, res) => {
-  const intent = (req.body.intent || '').toLowerCase();
-  const matches = manifest.actions.map(a => ({
+  const intent = String((req.body && req.body.intent) || '').toLowerCase();
+  const matches = ACTIONS.map((a) => ({
     id: a.id,
     summary: a.summary,
-    confidence: intent.includes('echo') || intent.includes('test') ? 0.95 : 0.5,
+    confidence: intent && (a.id.includes(intent.split(' ')[0]) || a.summary.toLowerCase().includes(intent)) ? 0.9 : 0.4,
     estimated_cost_eur: '0',
   }));
   res.json({ matching_actions: matches });
 });
 
-// ---------------------------------------------------------------------------
-// Billing
-// ---------------------------------------------------------------------------
-
+// Billing + subscribe
 app.get('/oap/billing', (req, res) => {
   const principalDid = req.query.principal_did;
-  const sub = subscriptions.get(principalDid);
-  res.json({ subscription: sub || null, pricing: manifest.pricing });
+  const row = principalDid ? stmt.selectSubscriptionByPrincipal.get(principalDid) : null;
+  res.json({ subscription: row ? JSON.parse(row.body_json) : null, pricing: manifest.pricing });
 });
-
-// ---------------------------------------------------------------------------
-// Subscribe
-// ---------------------------------------------------------------------------
-
 app.post('/oap/subscribe', (req, res) => {
-  const token = `oap_sub_live_${crypto.randomBytes(16).toString('hex')}`;
+  const principalDid = req.body?.principal_did;
+  if (!principalDid) return res.status(400).json({ error: 'principal_did required' });
   const sub = {
     subscription_id: generateUlid(),
-    principal_did: req.body.principal_did,
-    agent_did: req.body.agent_did,
+    principal_did: principalDid,
+    agent_did: req.body.agent_did || null,
     tool_did: TOOL_DID,
     tier: req.body.tier || 'free',
     status: 'active',
     created_at: new Date().toISOString(),
-    subscription_token: token,
+    subscription_token: `oap_sub_live_${crypto.randomBytes(16).toString('hex')}`,
   };
-  subscriptions.set(req.body.principal_did, sub);
-  createReceipt('subscription', req, sub);
+  stmt.insertSubscription.run(sub.subscription_id, principalDid, sub.tier, 'active', sub.created_at, JSON.stringify(sub));
+  persistReceipt('subscription', principalDid, sub.agent_did, null, req.body, sub);
   res.json(sub);
 });
-
 app.delete('/oap/subscribe/:id', (req, res) => {
-  for (const [key, sub] of subscriptions) {
-    if (sub.subscription_id === req.params.id) {
-      sub.status = 'canceled';
-      sub.canceled_at = new Date().toISOString();
-      return res.json(sub);
-    }
-  }
-  res.status(404).json({ error: 'not_found' });
+  const info = stmt.cancelSubscription.run('canceled', new Date().toISOString(), req.params.id);
+  if (info.changes === 0) return res.status(404).json({ error: 'not_found' });
+  res.json({ subscription_id: req.params.id, status: 'canceled', canceled_at: new Date().toISOString() });
 });
 
-// ---------------------------------------------------------------------------
-// Receipts (diagnostic, not part of OAP spec but useful)
-// ---------------------------------------------------------------------------
-
-app.get('/oap/receipts', (req, res) => {
-  const principalDid = req.query.principal_did;
-  const filtered = principalDid
-    ? receipts.filter(r => r.principal_did === principalDid)
-    : receipts;
-  res.json({ receipts: filtered, chain_valid: true });
+// Conformance receipt (runtime self-attestation; for audited use attest.js in CI)
+app.get('/oap/conformance-receipt', (_req, res) => {
+  const claimed = ['L0', 'L1', 'L2', 'L3'];
+  const core = {
+    receipt_id: `urn:oap:conformance:${crypto.randomBytes(12).toString('hex')}`,
+    type: 'conformance',
+    timestamp: new Date().toISOString(),
+    implementation: { did: TOOL_DID, name: 'OAP Reference Server', version: '1.0.0' },
+    suite: { name: 'oap-reference-runtime', version: '1.0.0', spec_version: '1.0' },
+    target: { uri: `http://${TOOL_DOMAIN}` },
+    claimed_levels: claimed,
+    profile: 'standard',
+    results_summary: { note: 'Runtime self-attestation only. For an audited Receipt, run oap-spec/test-suite/attest.js in CI.' },
+    validity: {
+      not_before: new Date().toISOString(),
+      not_after: new Date(Date.now() + 90 * 24 * 3600 * 1000).toISOString(),
+    },
+    previous_receipt_hash: 'genesis',
+  };
+  const sigValue = signEd25519(core);
+  res.json({ ...core, signatures: [{ by: `${TOOL_DID}#oap-signing`, alg: 'EdDSA', value: sigValue }] });
 });
 
-// ---------------------------------------------------------------------------
-// Start
-// ---------------------------------------------------------------------------
+// ─────────────────────────────────────────────────────────────────────────────
+// Boot
+// ─────────────────────────────────────────────────────────────────────────────
 
-app.listen(PORT, () => {
-  console.log(`OAP Reference Server running on port ${PORT}`);
-  console.log(`Manifest: http://localhost:${PORT}/.well-known/oap-tool.json`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`OAP Reference Server (L4-ready) listening on port ${PORT}`);
+    console.log(`  Manifest: http://${TOOL_DOMAIN}/.well-known/oap-tool.json`);
+    console.log(`  DID:      http://${TOOL_DOMAIN}/.well-known/did.json`);
+    console.log(`  Tool DID: ${TOOL_DID}`);
+    console.log(`  DB:       ${DB_PATH}`);
+    console.log(`  Key:      ${KEY_PATH}`);
+  });
+}
 
 module.exports = app;

--- a/reference/server/test/smoke.test.js
+++ b/reference/server/test/smoke.test.js
@@ -1,0 +1,142 @@
+/**
+ * Smoke test for the OAP Reference Server.
+ *
+ * Boots the Express app on an ephemeral port, exercises every declared Action
+ * (echo, compute_hash, store_note, request_cooling_off), then exercises the
+ * audit, deletion, and discover endpoints. Verifies signed receipts are
+ * Ed25519-verifiable against the published did.json.
+ *
+ * Used by CI in .github/workflows/release.yml.
+ */
+
+const crypto = require('crypto');
+const path = require('path');
+const fs = require('fs');
+
+// Use a temp DB and key path so smoke runs do not pollute the working tree.
+const TMP = fs.mkdtempSync(path.join(require('os').tmpdir(), 'oap-ref-'));
+process.env.OAP_DB_PATH = path.join(TMP, 'smoke.db');
+process.env.OAP_SIGNING_KEY_PEM = path.join(TMP, 'smoke-key.pem');
+process.env.PORT = '0'; // express picks ephemeral
+process.env.TOOL_DOMAIN = 'localhost:0';
+
+const app = require('../server.js');
+
+let failed = 0;
+function ok(name, cond, detail) {
+  if (cond) console.log(`  ok  ${name}`);
+  else { console.log(`  FAIL ${name} :: ${detail || ''}`); failed++; }
+}
+
+async function run() {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const base = `http://127.0.0.1:${port}`;
+
+  try {
+    // 1. Manifest
+    const manifest = await (await fetch(`${base}/.well-known/oap-tool.json`)).json();
+    ok('manifest served', manifest.oap_version === '1.0');
+    ok('manifest declares >= 4 actions', manifest.actions.length >= 4);
+    ok('manifest declares conformance_receipt endpoint', !!manifest.endpoints.conformance_receipt);
+
+    // 2. did.json
+    const did = await (await fetch(`${base}/.well-known/did.json`)).json();
+    ok('did.json id matches manifest', did.id === manifest.tool.did);
+    ok('did.json has Ed25519 verification method',
+       did.verificationMethod.some((v) => v.publicKeyJwk && v.publicKeyJwk.crv === 'Ed25519'));
+
+    const publicJwk = did.verificationMethod[0].publicKeyJwk;
+    const publicKey = crypto.createPublicKey({ key: publicJwk, format: 'jwk' });
+
+    function canonicalize(obj) {
+      if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+      if (Array.isArray(obj)) return '[' + obj.map(canonicalize).join(',') + ']';
+      const keys = Object.keys(obj).sort();
+      return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalize(obj[k])).join(',') + '}';
+    }
+
+    function makeUlid() {
+      const A = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+      let s = ''; for (let i = 0; i < 26; i++) s += A[Math.floor(Math.random() * 32)];
+      return s;
+    }
+
+    async function invoke(action, input, opts = {}) {
+      const r = await fetch(`${base}/oap/invoke`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/oap+json', ...(opts.headers || {}) },
+        body: JSON.stringify({
+          oap_version: '1.0', request_id: makeUlid(),
+          principal_did: opts.principal || 'did:plc:smoke',
+          agent_did: 'did:assistnet:smoke',
+          action, input,
+          context: { locale: 'en-US', currency: 'EUR', jurisdiction_user: 'DE', jurisdiction_agent: 'DE' },
+          signature: { alg: 'EdDSA', kid: 'probe', value: 'probe' },
+        }),
+      });
+      return { status: r.status, body: await r.json() };
+    }
+
+    // 3. Each action
+    const echo = await invoke('echo', { hello: 'world' });
+    ok('echo 200', echo.status === 200);
+    ok('echo returns input', echo.body.output && echo.body.output.echo && echo.body.output.echo.hello === 'world');
+
+    const hash = await invoke('compute_hash', { value: 'oap' });
+    ok('compute_hash 200', hash.status === 200);
+    ok('compute_hash returns sha256',
+       hash.body.output && hash.body.output.digest_hex === crypto.createHash('sha256').update('oap').digest('hex'));
+
+    // store_note requires Bearer auth
+    const noteUnauthed = await invoke('store_note', { content: 'x' });
+    ok('store_note rejects without Bearer', noteUnauthed.status === 401);
+    const noteAuthed = await invoke('store_note', { content: 'reference smoke' }, { headers: { Authorization: 'Bearer smoke-token' } });
+    ok('store_note accepts with Bearer', noteAuthed.status === 200);
+    ok('store_note returns note_id', !!noteAuthed.body.output?.note_id);
+
+    const cooling = await invoke('request_cooling_off', { for_action_id: 'echo' });
+    ok('request_cooling_off 200', cooling.status === 200);
+    ok('request_cooling_off returns wait_seconds', typeof cooling.body.output?.wait_seconds === 'number');
+
+    // 4. Verify receipt signature
+    const audit = await (await fetch(`${base}/oap/audit?principal_did=did:plc:smoke`)).json();
+    ok('audit returns receipts', Array.isArray(audit.receipts) && audit.receipts.length >= 4);
+    const sample = audit.receipts[0];
+    const sig = sample.signatures[0];
+    const sampleCore = { ...sample };
+    delete sampleCore.signatures;
+    delete sampleCore.self_hash;
+    const verified = crypto.verify(null, Buffer.from(canonicalize(sampleCore)), publicKey, Buffer.from(sig.value, 'base64url'));
+    ok('receipt signature verifies under did.json key', verified);
+
+    // 5. Deletion
+    const del = await (await fetch(`${base}/oap/data/delete`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ principal_did: 'did:plc:smoke' }),
+    })).json();
+    ok('deletion receipt has urn:oap:deletion id', /^urn:oap:deletion:/.test(del.receipt_id));
+    ok('deletion receipt is signed', del.signature && del.signature.alg === 'EdDSA');
+
+    // 6. Discover
+    const disc = await (await fetch(`${base}/oap/discover`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ intent: 'echo something back' }),
+    })).json();
+    ok('discover returns matches', Array.isArray(disc.matching_actions) && disc.matching_actions.length === 4);
+
+    // 7. Conformance receipt
+    const cr = await (await fetch(`${base}/oap/conformance-receipt`)).json();
+    ok('conformance receipt signed', cr.signatures && cr.signatures[0].alg === 'EdDSA');
+    ok('conformance receipt claims L0+L1+L2+L3', JSON.stringify(cr.claimed_levels) === JSON.stringify(['L0', 'L1', 'L2', 'L3']));
+
+  } finally {
+    server.close();
+  }
+
+  console.log('---');
+  console.log(failed === 0 ? `PASS (smoke)` : `FAIL ${failed} check(s)`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+run().catch((e) => { console.error(e); process.exit(2); });

--- a/rfcs/RFC-0025-non-commercial-conformance-profile.md
+++ b/rfcs/RFC-0025-non-commercial-conformance-profile.md
@@ -75,4 +75,4 @@ Falsely claiming a Non-Commercial Profile while charging users is a Manifest non
 
 ## 8. Reference implementation
 
-The first known L1-NC implementation is `assistant-net.vercel.app` (BYOK personal-AI assistant, source at `github.com/till-fengler/assistant-net`). Its Conformance Receipt is published at `https://assistant-net.vercel.app/api/oap/conformance-receipt` and anchored in `openagentprotocol-OAP/oap-registry/implementations/assistant-net.json`.
+The first known L1-NC implementation is `assistant-net.vercel.app` (a BYOK personal-AI assistant reference implementation). Its Conformance Receipt is published at `https://assistant-net.vercel.app/oap-conformance-receipt.json` and anchored in `openagentprotocol-OAP/oap-registry/implementations/assistant-net.json`.

--- a/rfcs/RFC-0026-registry-protocol.md
+++ b/rfcs/RFC-0026-registry-protocol.md
@@ -55,7 +55,7 @@ oap-registry/
   "conformance_receipt_sha256": "5bd9...e7c1",
   "issued_at": "2026-05-04T08:00:00Z",
   "expires_at": "2026-08-02T08:00:00Z",
-  "open_source": "https://github.com/till-fengler/assistant-net",
+  "open_source": null,
   "license": "Apache-2.0",
   "non_commercial": true,
   "contact": "oap@assistant-net.vercel.app"


### PR DESCRIPTION
Closes the production-readiness gap on the OAP-spec ecosystem identified in the audit:

## What this PR delivers

### 1. L4-ready Reference Server (`reference/server/`)
Rewritten as a real implementation, not a scaffold:
- **Persistence**: better-sqlite3 (`oap-server.db`) with WAL journal mode. Receipts, subscriptions, incidents, rate buckets, and the hash-chain tip are all durably stored.
- **Real Ed25519 signing**: Every Receipt and Deletion Receipt is signed via a real Ed25519 key. Auto-bootstraps a key into `reference-key.pem` on first run, or reads from `OAP_SIGNING_KEY_PEM` in production.
- **Published `.well-known/did.json`**: JsonWebKey2020 verification method with the matching public key, so any Verifier can resolve and check signatures.
- **Bearer-Auth on write actions**: `store_note` rejects without `Authorization: Bearer`.
- **Per-action RPM limiter**: Honors `rate_limit.rpm` declared per Action.
- **4 declared Actions**: `echo`, `compute_hash`, `store_note` (write), `request_cooling_off` (RFC-0017 §6 demo).
- **Signed Deletion Receipt** conforming to `oap-deletion-receipt.schema.json` (`urn:oap:deletion:` URN, EdDSA signature).

### 2. Smoke tests
- **`reference/server/test/smoke.test.js`** (21 checks). Verifies every endpoint, every Action, that signatures actually verify under the published did.json key, that write actions reject without Bearer, that deletion emits a signed Deletion Receipt.
- **`adapters/__tests__/smoke.test.js`** (16 checks). Boots the Reference Server on an ephemeral port and exercises **all four** adapters (mcp, a2a, openai-functions, langgraph) end-to-end against it.

### 3. CI pipeline
- **`validate.yml`**: now runs `npm run smoke` for the Reference Server and the adapter smoke tests on every push and PR.
- **`release.yml`**: tag-driven (push of `v*` tag, or manual). Gates a release on: ajv-strict schemas, ref-server smoke, full conformance test-suite (schema + behavior + charter), adapter smoke. Then generates a **signed self-Conformance Receipt** for the Reference Server using the repo signing key and attaches it to the GitHub Release. Falls back to a throwaway ephemeral key if `OAP_REFERENCE_SIGNING_PEM_B64` is not set.

## Verified locally
- Reference server smoke: **21/21 PASS**
- Adapter smoke: **16/16 PASS**
- Full conformance test-suite against the new server: **44/44 PASS** (Linux CI parity)

## Required for full release flow
Repo secret `OAP_REFERENCE_SIGNING_PEM_B64` (base64 of the Ed25519 PEM) so the release pipeline can sign with a stable key. Without it, the workflow generates a throwaway key per run and emits a warning.